### PR TITLE
Add repository field to package.json

### DIFF
--- a/projects/ng-bullet/package.json
+++ b/projects/ng-bullet/package.json
@@ -6,6 +6,10 @@
       "name": "nikitai",
       "email": "nikita.yakovenko@gmail.com"
     },
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/topnotch48/ng-bullet-workspace.git"
+    },
     "description": "Angular library which drastically improves execution time of your component's unit tests",
     "keywords": [
         "ng",


### PR DESCRIPTION
Note that there is currently no link from https://www.npmjs.com/package/ng-bullet to the github repository - believe adding this field should solve this.